### PR TITLE
feat(ci): optimize dependabot for micro-tool scale

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 10
@@ -20,7 +20,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/tests/docker"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 5
@@ -31,12 +31,20 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+    groups:
+      test-dev-deps:
+        patterns:
+          - "prettier"
+          - "eslint"
+          - "typescript"
+          - "rollup"
+          - "nodemon"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 5
@@ -52,7 +60,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/tests/docker"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Change dependabot schedule from weekly to monthly updates
- Group test dependencies (prettier, eslint, typescript, rollup, nodemon) to reduce PR noise
- Maintain security updates while improving development efficiency

## Changes
- Updated `.github/dependabot.yml` to use monthly schedule for all ecosystems
- Added dependency grouping for test/dev dependencies in `/tests/docker`
- Reduced update frequency while maintaining security coverage

## Benefits
- 75% reduction in dependabot PR frequency (weekly → monthly)
- Batching of test dependency updates into single PRs
- Less noise, more efficient review process
- Maintains security posture for micro-tool scale

## Test plan
- [x] Verify dependabot configuration syntax is valid
- [x] Confirm grouping patterns match test dependencies
- [x] Check monthly schedule is properly configured

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 4.6