### PR TITLE
feat(ux): show '[not installed]' for uninstalled packages

### DIFF
--- a/lib/brew-change-brew.sh
+++ b/lib/brew-change-brew.sh
@@ -223,7 +223,9 @@ show_package_changelog() {
                         echo "Already up to date at version $current_version ✓"
                         return 0
                     else
-                        echo "📦 $package: ${current_version:-unknown} → ${latest_version:-unknown}"
+                        local display_current="${current_version:-[not installed]}"
+                        local display_latest="${latest_version:-unknown}"
+                        echo "📦 $package: $display_current → $display_latest"
                         echo ""
                         echo "Version information unavailable."
                         return 0
@@ -297,7 +299,11 @@ show_package_changelog() {
             fi
         fi
 
-        echo "📦 $package: $current_version → unknown"
+        local display_current="$current_version"
+        if [[ "$display_current" == "unknown" || -z "$display_current" ]]; then
+            display_current="[not installed]"
+        fi
+        echo "📦 $package: $display_current → unknown"
         echo "Package information not available - this might be:"
         echo "  • A cask without GitHub repository"
         echo "  • A package using non-GitHub download sources"

--- a/lib/brew-change-utils.sh
+++ b/lib/brew-change-utils.sh
@@ -810,6 +810,11 @@ create_package_header() {
         fi
     fi
 
+    # Replace "unknown" with "[not installed]" for better UX
+    if [[ "$current_version" == "unknown" ]]; then
+        current_version="[not installed]"
+    fi
+
     # Build package header with optional breaking changes indicator
     local breaking_indicator=""
     if [[ "$IDENTIFY_BREAKING" == "true" && "$has_breaking" == "true" ]]; then


### PR DESCRIPTION
## Summary

- Replace `'unknown'` with `'[not installed]'` in version display for uninstalled packages
- Makes package status immediately clear to users

## Context

Resolves #20

When querying an uninstalled package (e.g., `brewo ccal`), the previous output was:

```
📦 ccal: unknown → 2.5.3 (no release date)
```

The `'unknown'` label indicates the package isn't installed, but this wasn't immediately obvious to users. This could cause confusion about whether the package is installed or not.

## Changes

- **lib/brew-change-utils.sh**: Updated `create_package_header()` to replace `"unknown"` with `"[not installed]"`
- **lib/brew-change-brew.sh**: Updated two direct display sites to use `"[not installed]"` instead of `"unknown"`

## Example

**Before:**
```
📦 ccal: unknown → 2.5.3 (no release date)
```

**After:**
```
📦 ccal: [not installed] → 2.5.3 (no release date)
```

This makes the package status immediately clear while preserving the tool's ability to query uninstalled packages for research/pre-installation evaluation purposes.

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 4.7
