### PR TITLE
chore(release): bump version to 1.6.0

### DIFF
--- a/brew-change
+++ b/brew-change
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # Version information
-readonly VERSION="1.5.14"
+readonly VERSION="1.6.0"
 
 # Set UTF-8 locale to handle emojis and special characters
 # This must be set before any text processing


### PR DESCRIPTION
## Summary
- Bump version from 1.5.14 to 1.6.0 for multi-package support release

Follows existing release pattern. Merge to trigger release workflow.

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5.1