### PR TITLE
feat(upgrade): add interactive selective upgrade with -u flag

### DIFF
--- a/brew-change
+++ b/brew-change
@@ -43,6 +43,7 @@ source "$LIB_DIR/brew-change-brew.sh"
 source "$LIB_DIR/brew-change-non-github.sh"
 source "$LIB_DIR/brew-change-display.sh"
 source "$LIB_DIR/brew-change-parallel.sh"
+source "$LIB_DIR/brew-change-upgrade.sh"
 
 # Verify dependencies
 if ! verify_dependencies; then
@@ -72,6 +73,8 @@ Options:
   -a, --all            Show detailed changelog for all outdated packages (parallel)
   -v, --verbose        Show outdated packages with version numbers (like 'brew outdated -v')
   -b, --id-breaking    Highlight packages with breaking changes (implies -a)
+  -u, --upgrade        Show changelogs then offer selective upgrade (implies -a, -b)
+                        Set BREW_CHANGE_UPGRADE_INTERACTIVE=true to enable execution
   -h, --help           Show this help message
       --version        Show version information
 
@@ -86,6 +89,9 @@ Examples:
   brew-change -b                # Same as -a -b (shorthand)
   brew-change -b node python    # Check specific packages for breaking changes
   brew-change --id-breaking     # Same as -a -b (long form)
+  brew-change -u                # Show changelogs with upgrade summary
+  BREW_CHANGE_UPGRADE_INTERACTIVE=true brew-change -u
+                                # Show changelogs + interactive upgrade prompt
   brew-change                   # Show simple outdated list (package names only)
   brew-change --version         # Show version information
 
@@ -96,6 +102,7 @@ EOF
 SHOW_ALL="false"
 SHOW_VERSIONS="false"
 IDENTIFY_BREAKING="false"
+UPGRADE_MODE="false"
 PACKAGES=()
 
 while [[ $# -gt 0 ]]; do
@@ -106,6 +113,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -b|--id-breaking)
             IDENTIFY_BREAKING="true"
+            shift
+            ;;
+        -u|--upgrade)
+            UPGRADE_MODE="true"
             shift
             ;;
         -v|--verbose)
@@ -296,6 +307,12 @@ else
         SHOW_ALL="true"
     fi
 
+    # If -u is used, implicitly enable -a and -b
+    if [ "$UPGRADE_MODE" = "true" ]; then
+        SHOW_ALL="true"
+        IDENTIFY_BREAKING="true"
+    fi
+
     if [ "$SHOW_ALL" = "true" ]; then
         # Count total outdated packages
         total_packages=0
@@ -332,9 +349,23 @@ else
         # Note: outdated_packages is passed as argument to process_packages_parallel, no export needed
         export IDENTIFY_BREAKING  # Make breaking flag available to subprocesses
         export BREW_CHANGE_PARALLEL_MODE="true"  # Disable interactive prompts in parallel mode
+
+        # If upgrade mode, create a tracking directory for breaking-change status
+        if [[ "$UPGRADE_MODE" == "true" ]]; then
+            UPGRADE_STATUS_DIR=$(mktemp -d -t brew-change-status.XXXXXX 2>/dev/null)
+            export UPGRADE_STATUS_DIR
+            register_temp_dir "$UPGRADE_STATUS_DIR"
+        fi
+
         process_packages_parallel "$outdated_packages" "$PARALLEL_JOBS"
-        
-        echo "Run 'brew upgrade' to upgrade all packages, or 'brew upgrade <package>' for individual packages."
+
+        if [[ "$UPGRADE_MODE" == "true" ]]; then
+            # Collect breaking-change status and run upgrade flow
+            collect_upgrade_status "$UPGRADE_STATUS_DIR"
+            run_upgrade_prompt "$outdated_packages"
+        else
+            echo "Run 'brew upgrade' to upgrade all packages, or 'brew upgrade <package>' for individual packages."
+        fi
     elif [ "$SHOW_VERSIONS" = "true" ]; then
         # Show list with versions like brew outdated -v
         show_outdated_with_versions

--- a/lib/brew-change-config.sh
+++ b/lib/brew-change-config.sh
@@ -81,6 +81,12 @@ if [[ -z "${BREW_CHANGE_DOCS_REPO:-}" ]]; then
     readonly BREW_CHANGE_DOCS_REPO="false"
 fi
 
+# Upgrade interactive mode — safety gate for brew upgrade execution
+# Must be "true" to enable the interactive upgrade prompt with -u flag
+if [[ -z "${BREW_CHANGE_UPGRADE_INTERACTIVE:-}" ]]; then
+    BREW_CHANGE_UPGRADE_INTERACTIVE="false"
+fi
+
 # Calculate optimal parallel jobs based on system resources
 cpu_count=1
 memory_gb=1
@@ -153,7 +159,8 @@ fi
 if [[ -z "${BREW_CHANGE_SUBPROCESS:-}" ]]; then
     # Store temp files for cleanup
     TEMP_FILES=()
-    
+    TEMP_DIRS=()
+
     cleanup() {
         local has_temp_files=false
         
@@ -200,6 +207,13 @@ if [[ -z "${BREW_CHANGE_SUBPROCESS:-}" ]]; then
                 fi
             done
 
+            # Remove all registered temp directories
+            for temp_dir in "${TEMP_DIRS[@]:-}"; do
+                if [[ -n "$temp_dir" && -d "$temp_dir" ]]; then
+                    rm -rf "$temp_dir" 2>/dev/null || true
+                fi
+            done
+
             # Cleanup any remaining temp files in cache directory
             if [[ -n "${CACHE_DIR:-}" && -d "$CACHE_DIR" ]]; then
                 find "$CACHE_DIR" -name ".*.tmp.$$" -type f -delete 2>/dev/null || true
@@ -233,6 +247,14 @@ if [[ -z "${BREW_CHANGE_SUBPROCESS:-}" ]]; then
         local temp_file="$1"
         if [[ -n "$temp_file" ]]; then
             TEMP_FILES+=("$temp_file")
+        fi
+    }
+
+    # Function to register temp directories for cleanup
+    register_temp_dir() {
+        local temp_dir="$1"
+        if [[ -n "$temp_dir" ]]; then
+            TEMP_DIRS+=("$temp_dir")
         fi
     }
     

--- a/lib/brew-change-display.sh
+++ b/lib/brew-change-display.sh
@@ -526,6 +526,11 @@ show_package_changelog_full() {
         fi
     fi
 
+    # Write breaking status for upgrade mode tracking (only when UPGRADE_STATUS_DIR is set)
+    if [[ -n "${UPGRADE_STATUS_DIR:-}" && -d "${UPGRADE_STATUS_DIR}" ]]; then
+        printf '%s\t%s\n' "$package" "$has_breaking" >> "${UPGRADE_STATUS_DIR}/results.tsv"
+    fi
+
     # Create package header using shared function
     create_package_header "$package" "$current_version" "$latest_version" "$relative_date" "$package_info" "$has_breaking"
     echo ""

--- a/lib/brew-change-interactive.sh
+++ b/lib/brew-change-interactive.sh
@@ -45,3 +45,134 @@ prompt_for_confirmation_with_timeout() {
 is_interactive_mode() {
     [[ -t 0 ]]
 }
+
+# Four-option upgrade action prompt
+# Args:
+#   $1: Count of packages with breaking changes
+#   $2: Count of packages without breaking changes (safe)
+#   $3: Total outdated package count
+# Returns (via echo to stdout):
+#   "all", "safe", "choose", or "cancel"
+prompt_upgrade_action() {
+    local breaking_count="$1"
+    local safe_count="$2"
+    local total_count="$3"
+
+    # Determine default based on whether breaking changes exist
+    local default_option="a"
+    if [[ "$breaking_count" -gt 0 ]]; then
+        default_option="s"
+    fi
+
+    local prompt_text="[a]ll / [s]afe-only ($safe_count) / [c]hoose / cancel [$default_option]: "
+
+    local response=""
+    local read_timeout=1
+    local total_timeout=300
+    local elapsed=0
+
+    echo -n "$prompt_text"
+    while [[ $elapsed -lt $total_timeout && -z "$response" ]]; do
+        if IFS= read -r -t $read_timeout response 2>/dev/null; then
+            break
+        fi
+        elapsed=$((elapsed + read_timeout))
+    done
+
+    # Empty response -> use default
+    if [[ -z "$response" ]]; then
+        response="$default_option"
+    fi
+
+    case "$response" in
+        a|all)    echo "all" ;;
+        s|safe)   echo "safe" ;;
+        c|choose) echo "choose" ;;
+        *)        echo "cancel" ;;
+    esac
+}
+
+# Interactive per-package selection prompt
+# Args:
+#   $@: Array of package names to choose from
+# Returns (via echo to stdout):
+#   Newline-separated list of selected package names
+prompt_package_selection() {
+    local packages=("$@")
+    local selected=()
+
+    echo ""
+    echo "Select packages to upgrade:"
+    echo ""
+
+    for pkg in "${packages[@]}"; do
+        local default_response="y"
+        local breaking_marker=""
+
+        if is_package_breaking "$pkg"; then
+            default_response="n"
+            breaking_marker=" ⚠️"
+        fi
+
+        local prompt_text="  Upgrade $pkg$breaking_marker? [Y/n]: "
+        if [[ "$default_response" == "n" ]]; then
+            prompt_text="  Upgrade $pkg$breaking_marker? [y/N]: "
+        fi
+
+        local response=""
+        local read_timeout=1
+        local total_timeout=60
+        local elapsed=0
+
+        echo -n "$prompt_text"
+        while [[ $elapsed -lt $total_timeout && -z "$response" ]]; do
+            if IFS= read -r -t $read_timeout response 2>/dev/null; then
+                break
+            fi
+            elapsed=$((elapsed + read_timeout))
+        done
+
+        if [[ -z "$response" ]]; then
+            response="$default_response"
+        fi
+
+        if [[ "$response" =~ ^[Yy]$ ]]; then
+            selected+=("$pkg")
+        elif [[ "$response" =~ ^[Nn]$ ]]; then
+            :
+        else
+            # On invalid input, use default
+            if [[ "$default_response" == "y" ]]; then
+                selected+=("$pkg")
+            fi
+        fi
+    done
+
+    if [[ ${#selected[@]} -gt 0 ]]; then
+        printf '%s\n' "${selected[@]}"
+    fi
+}
+
+# Final confirmation before running brew upgrade
+# Args:
+#   $1: Description of what will be upgraded (e.g., "3 safe packages")
+#   $2...: Package names (optional, for display)
+# Returns:
+#   0: User confirmed
+#   1: User declined or timeout
+prompt_upgrade_confirmation() {
+    local description="$1"
+    shift
+    local packages=("$@")
+
+    echo ""
+    if [[ ${#packages[@]} -gt 0 ]]; then
+        echo "About to upgrade: $description"
+        echo "  ${packages[*]}"
+    else
+        echo "About to upgrade: $description"
+    fi
+    echo ""
+
+    prompt_for_confirmation "Proceed with upgrade? (y/N): "
+}

--- a/lib/brew-change-upgrade.sh
+++ b/lib/brew-change-upgrade.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# Upgrade orchestration functions for brew-change
+# Handles the interactive selective upgrade flow triggered by -u/--upgrade flag
+
+# Arrays populated by collect_upgrade_status
+BREAKING_PKGS=()
+SAFE_PKGS=()
+
+# Collect breaking-change status from parallel processing subshells
+# Args:
+#   $1: Path to the temporary directory containing results.tsv
+# Populates global arrays:
+#   BREAKING_PKGS[] - packages flagged with breaking changes
+#   SAFE_PKGS[]     - packages not flagged
+collect_upgrade_status() {
+    local status_dir="$1"
+    local results_file="${status_dir}/results.tsv"
+
+    BREAKING_PKGS=()
+    SAFE_PKGS=()
+
+    if [[ ! -f "$results_file" ]]; then
+        return 0  # No status file means no breaking data available
+    fi
+
+    while IFS=$'\t' read -r pkg_name breaking_status; do
+        if [[ -z "$pkg_name" ]]; then
+            continue
+        fi
+
+        if [[ "$breaking_status" == "true" ]]; then
+            BREAKING_PKGS+=("$pkg_name")
+        else
+            SAFE_PKGS+=("$pkg_name")
+        fi
+    done < "$results_file"
+}
+
+# Check if a package was flagged as having breaking changes
+# Args:
+#   $1: Package name
+# Returns:
+#   0 if package has breaking changes, 1 otherwise
+is_package_breaking() {
+    local target="$1"
+    local pkg
+    for pkg in "${BREAKING_PKGS[@]+"${BREAKING_PKGS[@]}"}"; do
+        if [[ "$pkg" == "$target" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Print the upgrade summary line
+# Args:
+#   $1: The outdated packages JSON from brew outdated --json=v2
+print_upgrade_summary() {
+    local outdated_packages="$1"
+
+    local total_count=0
+    local breaking_count=${#BREAKING_PKGS[@]}
+    local safe_count=${#SAFE_PKGS[@]}
+
+    # Calculate total from JSON
+    total_count=$(echo "$outdated_packages" | jq -r '(.formulae | length) + (.casks | length)' 2>/dev/null || echo "0")
+
+    # Packages with no status entry (release notes unavailable) count as safe
+    local known_count=$((breaking_count + safe_count))
+    local unknown_count=$((total_count - known_count))
+    safe_count=$((safe_count + unknown_count))
+
+    echo ""
+    echo "---"
+    echo "Summary: $total_count packages outdated · $breaking_count with breaking changes · $safe_count appear safe"
+}
+
+# Print suggested upgrade command without executing
+# Args:
+#   $1: The outdated packages JSON
+print_upgrade_suggestion() {
+    local outdated_packages="$1"
+
+    local total_count=0
+    local breaking_count=${#BREAKING_PKGS[@]}
+    local safe_count=${#SAFE_PKGS[@]}
+
+    total_count=$(echo "$outdated_packages" | jq -r '(.formulae | length) + (.casks | length)' 2>/dev/null || echo "0")
+    # Packages with no status entry (release notes unavailable) count as safe
+    local unknown_count=$((total_count - breaking_count - safe_count))
+    safe_count=$((safe_count + unknown_count))
+
+    echo ""
+
+    if [[ $breaking_count -gt 0 ]]; then
+        if [[ ${#SAFE_PKGS[@]} -gt 0 ]]; then
+            echo "Suggested safe upgrade:"
+            echo "  brew upgrade ${SAFE_PKGS[*]}"
+            echo ""
+        fi
+        echo "To upgrade all packages:"
+        echo "  brew upgrade"
+    else
+        echo "No breaking changes detected. To upgrade all packages:"
+        echo "  brew upgrade"
+    fi
+
+    echo ""
+    echo "Tip: Set BREW_CHANGE_UPGRADE_INTERACTIVE=true to enable the interactive upgrade prompt."
+}
+
+# Run the interactive upgrade flow
+# Args:
+#   $1: The outdated packages JSON from brew outdated --json=v2
+run_upgrade_prompt() {
+    local outdated_packages="$1"
+
+    local breaking_count=${#BREAKING_PKGS[@]}
+
+    # Calculate safe count (including packages with no status)
+    local total_count=0
+    total_count=$(echo "$outdated_packages" | jq -r '(.formulae | length) + (.casks | length)' 2>/dev/null || echo "0")
+    local safe_count=$((total_count - breaking_count))
+
+    # Print summary (always shown in upgrade mode)
+    print_upgrade_summary "$outdated_packages"
+
+    # Non-interactive mode: print suggestion and exit
+    if ! is_interactive_mode; then
+        echo ""
+        echo "Non-interactive mode. Upgrade skipped."
+        if [[ ${#SAFE_PKGS[@]} -gt 0 ]]; then
+            echo "Suggested safe upgrade: brew upgrade ${SAFE_PKGS[*]}"
+        fi
+        echo "To upgrade all: brew upgrade"
+        return 0
+    fi
+
+    # Check safety gate: env var must be true for interactive prompt
+    if [[ "$BREW_CHANGE_UPGRADE_INTERACTIVE" != "true" ]]; then
+        print_upgrade_suggestion "$outdated_packages"
+        return 0
+    fi
+
+    # Interactive prompt
+    local action
+    action=$(prompt_upgrade_action "$breaking_count" "$safe_count" "$total_count")
+
+    case "$action" in
+        all)
+            execute_upgrade "all outdated packages" "all"
+            ;;
+        safe)
+            if [[ ${#SAFE_PKGS[@]} -eq 0 ]]; then
+                echo ""
+                echo "No safe packages to upgrade."
+                echo "All packages have breaking changes. Use [a]ll to upgrade everything."
+                return 0
+            fi
+            execute_upgrade "${#SAFE_PKGS[@]} safe packages" "safe"
+            ;;
+        choose)
+            # Build full package list from JSON
+            local all_pkgs=()
+            while IFS= read -r pkg; do
+                [[ -n "$pkg" && "$pkg" != "null" ]] && all_pkgs+=("$pkg")
+            done < <(echo "$outdated_packages" | jq -r '.formulae[].name // empty' 2>/dev/null)
+            while IFS= read -r pkg; do
+                [[ -n "$pkg" && "$pkg" != "null" ]] && all_pkgs+=("$pkg")
+            done < <(echo "$outdated_packages" | jq -r '.casks[].name // empty' 2>/dev/null)
+
+            if [[ ${#all_pkgs[@]} -eq 0 ]]; then
+                echo "No packages to choose from."
+                return 0
+            fi
+
+            local selected
+            selected=$(prompt_package_selection "${all_pkgs[@]}")
+
+            if [[ -z "$selected" ]]; then
+                echo ""
+                echo "No packages selected."
+                return 0
+            fi
+
+            local selected_count
+            selected_count=$(echo "$selected" | wc -l | tr -d ' ')
+            execute_upgrade "$selected_count selected packages" "selected" "$selected"
+            ;;
+        cancel|*)
+            echo ""
+            echo "Upgrade cancelled."
+            return 0
+            ;;
+    esac
+}
+
+# Execute brew upgrade for selected packages
+# Args:
+#   $1: Human-readable description of what's being upgraded
+#   $2: Mode - "all", "safe", or "selected"
+#   $3: (Optional) Newline-separated list of package names for "selected" mode
+execute_upgrade() {
+    local description="$1"
+    local mode="$2"
+    shift 2
+    local package_list="${*:-}"
+
+    local cmd_args=()
+
+    case "$mode" in
+        all)
+            # No args = upgrade everything outdated
+            ;;
+        safe)
+            cmd_args=("${SAFE_PKGS[@]}")
+            ;;
+        selected)
+            # Convert newline-separated to array
+            while IFS= read -r pkg; do
+                [[ -n "$pkg" ]] && cmd_args+=("$pkg")
+            done <<< "$package_list"
+            ;;
+    esac
+
+    # Final confirmation
+    if [[ ${#cmd_args[@]} -eq 0 ]]; then
+        if ! prompt_upgrade_confirmation "$description"; then
+            return 0
+        fi
+    else
+        if ! prompt_upgrade_confirmation "$description" "${cmd_args[@]}"; then
+            return 0
+        fi
+    fi
+
+    echo ""
+    if [[ ${#cmd_args[@]} -eq 0 ]]; then
+        echo "Running: brew upgrade"
+    else
+        echo "Running: brew upgrade ${cmd_args[*]}"
+    fi
+    echo ""
+
+    # Execute brew upgrade, capturing output
+    local upgrade_exit_code=0
+
+    if [[ ${#cmd_args[@]} -eq 0 ]]; then
+        brew upgrade || upgrade_exit_code=$?
+    else
+        brew upgrade "${cmd_args[@]}" || upgrade_exit_code=$?
+    fi
+
+    echo ""
+
+    if [[ $upgrade_exit_code -eq 0 ]]; then
+        echo "Upgrade completed successfully. ✓"
+    else
+        echo "Upgrade completed with errors (exit code $upgrade_exit_code)."
+        echo "Some packages may have failed to upgrade."
+        echo "Check the output above for details, or run 'brew doctor' to diagnose issues."
+    fi
+
+    return $upgrade_exit_code
+}


### PR DESCRIPTION
## Summary

Add `-u`/`--upgrade` flag that shows changelogs with breaking-change detection, then offers a selective upgrade prompt.

### What it does

- **Without env var**: `brew-change -u` shows changelogs + summary (how many packages outdated, how many have breaking changes) + a suggested safe upgrade command
- **With `BREW_CHANGE_UPGRADE_INTERACTIVE=true`**: shows a 4-option interactive prompt:
  - **[a]ll** — upgrade everything outdated
  - **[s]afe-only** — upgrade only packages without breaking changes
  - **[c]hoose** — pick packages individually (defaults yes for safe, no for breaking)
  - **cancel** — do nothing

### Key design decisions

| Decision | Rationale |
|----------|-----------|
| Safety gate env var | Prevents accidental `brew upgrade` execution — must opt-in explicitly |
| Side-channel `results.tsv` | Parallel subshells can't return structured data; atomic tab-separated appends |
| Defaults to safe-only | When breaking changes exist, the safer default protects the system |
| 4-option prompt | More useful than yes/no — users can granularly control what upgrades |

### Breaking-change detection

Uses the existing keyword-based detector (advisory, not authoritative). The human always chooses what to upgrade.

### Files changed

- `brew-change` — arg parsing + upgrade mode flow
- `lib/brew-change-upgrade.sh` — **new** orchestration module
- `lib/brew-change-interactive.sh` — 3 new prompt functions
- `lib/brew-change-config.sh` — env var + TEMP_DIRS cleanup
- `lib/brew-change-display.sh` — side-channel breaking-status write

### Testing

- `./brew-change --help` shows `-u` option
- `./brew-change` (bare) unchanged behavior
- `./brew-change -a -b` unchanged behavior
- `./brew-change -u` shows summary + suggested command
- All bash syntax checks pass

### Related

- Roadmap: Phase 3 — `--upgrade-interactive` (docs/standalone-roadmap.md)
- Complements Homebrew 6.0.0 ask mode (released June 11, 2026)

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5