### PR TITLE
feat(upgrade): add spinner + timer animation to action prompt

### DIFF
--- a/brew-change
+++ b/brew-change
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # Version information
-readonly VERSION="1.8.3"
+readonly VERSION="1.8.4"
 
 # Set UTF-8 locale to handle emojis and special characters
 # This must be set before any text processing

--- a/lib/brew-change-interactive.sh
+++ b/lib/brew-change-interactive.sh
@@ -46,7 +46,7 @@ is_interactive_mode() {
     [[ -t 0 ]]
 }
 
-# Four-option upgrade action prompt
+# Four-option upgrade action prompt with spinner + timer animation
 # Args:
 #   $1: Count of packages with breaking changes
 #   $2: Count of packages without breaking changes (safe)
@@ -65,26 +65,45 @@ prompt_upgrade_action() {
     fi
 
     local prompt_text="[a]ll / [s]afe-only ($safe_count) / [c]hoose / cancel [$default_option]: "
-
-    local response=""
+    local spinner_chars="⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
     local read_timeout=1
     local total_timeout=60
-    local reprint_interval=15
     local elapsed=0
+    local spinner_idx=0
 
-    # Write prompt to /dev/tty to bypass command substitution capture
-    echo -n "$prompt_text" > /dev/tty
+    local response=""
+    # Use a background subshell for spinner animation so it doesn't block read
+    local spinner_pid=""
+    local spin_tty="/dev/tty"
+
+    # Start spinner in background, writing to /dev/tty
+    (
+        local s_idx=0
+        local s_elapsed=0
+        local s_chars="⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+        local s_len=${#s_chars}
+        while true; do
+            sleep 0.1
+            s_idx=$(( (s_idx + 1) % s_len ))
+            s_elapsed=$(( s_elapsed + 1 ))
+            local s_sec=$(( s_elapsed / 10 ))
+            local frame="${s_chars:s_idx:1} ${s_sec}s"
+            printf "\r%s%s" "$prompt_text" "$frame" > "$spin_tty"
+        done
+    ) &
+    spinner_pid=$!
+
+    # Read user input with timeout
     while [[ $elapsed -lt $total_timeout && -z "$response" ]]; do
         if IFS= read -r -t $read_timeout response 2>/dev/null; then
             break
         fi
         elapsed=$((elapsed + read_timeout))
-        # Re-print prompt periodically so it stays visible
-        if [[ $elapsed -gt 0 && $((elapsed % reprint_interval)) -eq 0 ]]; then
-            echo "" > /dev/tty
-            echo -n "$prompt_text" > /dev/tty
-        fi
     done
+
+    # Stop spinner and clear the line
+    kill "$spinner_pid" 2>/dev/null; wait "$spinner_pid" 2>/dev/null
+    printf "\r%*s\r" "$(( ${#prompt_text} + 10 ))" "" > /dev/tty
 
     # Timeout with no input -> use default (not cancel)
     if [[ -z "$response" ]]; then


### PR DESCRIPTION
## Summary

Replace the noisy prompt re-print (every 15s, stacking 5 lines) with a smooth rotating braille spinner + elapsed timer:

```
[a]ll / [s]afe-only (21) / [c]hoose / cancel [a]: ⠹ 3s
```

## How it works

- Spinner runs in a background subshell writing to `/dev/tty` — doesn't block `read`
- Updates every 100ms via `printf "\r"` (carriage return, in-place overwrite)
- On input or timeout: spinner is killed, line cleared cleanly
- Timeout still uses advertised default (e.g. `[a]`)

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5