### PR TITLE
fix(upgrade): use 100ms poll rate for fluid spinner animation

### DIFF
--- a/brew-change
+++ b/brew-change
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # Version information
-readonly VERSION="1.8.5"
+readonly VERSION="1.8.6"
 
 # Set UTF-8 locale to handle emojis and special characters
 # This must be set before any text processing

--- a/lib/brew-change-interactive.sh
+++ b/lib/brew-change-interactive.sh
@@ -66,24 +66,27 @@ prompt_upgrade_action() {
 
     local prompt_text="[a]ll / [s]afe-only ($safe_count) / [c]hoose / cancel [$default_option]: "
     local spinner_chars="⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
-    local read_timeout=1
+    local read_timeout=0.1
     local total_timeout=60
-    local elapsed=0
+    local elapsed_ticks=0
+    local elapsed_secs=0
     local spinner_idx=0
+    local ticks_per_sec=10
     local prompt_width=$(( ${#prompt_text} + 6 ))
 
     local response=""
 
-    while [[ $elapsed -lt $total_timeout && -z "$response" ]]; do
+    while [[ $elapsed_secs -lt $total_timeout && -z "$response" ]]; do
         # Draw spinner + timer in-place via carriage return
-        local frame="${spinner_chars:spinner_idx:1} ${elapsed}s"
+        local frame="${spinner_chars:spinner_idx:1} ${elapsed_secs}s"
         printf "\r%s%s" "$prompt_text" "$frame" > /dev/tty
         spinner_idx=$(( (spinner_idx + 1) % ${#spinner_chars} ))
 
         if IFS= read -r -t $read_timeout response 2>/dev/null; then
             break
         fi
-        elapsed=$((elapsed + read_timeout))
+        elapsed_ticks=$((elapsed_ticks + 1))
+        elapsed_secs=$(( elapsed_ticks / ticks_per_sec ))
     done
 
     # Clear the spinner line


### PR DESCRIPTION
## Summary

Spinner was tied to 1s `read -t` poll — only advanced once/second. Use `read -t 0.1` for ~10fps animation. Timer still shows whole seconds via tick counter.

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5