### PR TITLE
fix(upgrade): change spinner timer from count-up to countdown

### DIFF
--- a/brew-change
+++ b/brew-change
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # Version information
-readonly VERSION="1.8.6"
+readonly VERSION="1.8.7"
 
 # Set UTF-8 locale to handle emojis and special characters
 # This must be set before any text processing

--- a/lib/brew-change-interactive.sh
+++ b/lib/brew-change-interactive.sh
@@ -69,16 +69,16 @@ prompt_upgrade_action() {
     local read_timeout=0.1
     local total_timeout=60
     local elapsed_ticks=0
-    local elapsed_secs=0
+    local remaining_secs=60
     local spinner_idx=0
     local ticks_per_sec=10
     local prompt_width=$(( ${#prompt_text} + 6 ))
 
     local response=""
 
-    while [[ $elapsed_secs -lt $total_timeout && -z "$response" ]]; do
-        # Draw spinner + timer in-place via carriage return
-        local frame="${spinner_chars:spinner_idx:1} ${elapsed_secs}s"
+    while [[ $remaining_secs -gt 0 && -z "$response" ]]; do
+        # Draw spinner + countdown timer in-place via carriage return
+        local frame="${spinner_chars:spinner_idx:1} ${remaining_secs}s"
         printf "\r%s%s" "$prompt_text" "$frame" > /dev/tty
         spinner_idx=$(( (spinner_idx + 1) % ${#spinner_chars} ))
 
@@ -86,7 +86,7 @@ prompt_upgrade_action() {
             break
         fi
         elapsed_ticks=$((elapsed_ticks + 1))
-        elapsed_secs=$(( elapsed_ticks / ticks_per_sec ))
+        remaining_secs=$(( total_timeout - elapsed_ticks / ticks_per_sec ))
     done
 
     # Clear the spinner line


### PR DESCRIPTION
## Changes

- Timer now counts down from 60s → 0s instead of 0s → 60s
- Makes timeout deadline visible at a glance

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5