### PR TITLE
fix(upgrade): show cancellation message on confirmation timeout

### DIFF
--- a/brew-change
+++ b/brew-change
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # Version information
-readonly VERSION="1.8.7"
+readonly VERSION="1.8.8"
 
 # Set UTF-8 locale to handle emojis and special characters
 # This must be set before any text processing

--- a/lib/brew-change-interactive.sh
+++ b/lib/brew-change-interactive.sh
@@ -188,5 +188,10 @@ prompt_upgrade_confirmation() {
     fi
     echo "" > /dev/tty
 
-    prompt_for_confirmation "Proceed with upgrade? (y/N): "
+    if prompt_for_confirmation_with_timeout "Proceed with upgrade? (y/N): " 60; then
+        return 0
+    else
+        echo "Upgrade cancelled." > /dev/tty
+        return 1
+    fi
 }


### PR DESCRIPTION
## Summary

- Confirmation prompt reduced from 300s to 60s timeout (matches spinner)
- Prints "Upgrade cancelled." on decline or timeout instead of silently exiting
- Fixes confusing behavior where user sees "About to upgrade" then nothing for 5 minutes

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5