### PR TITLE
refactor(upgrade): remove redundant confirmation prompt

### DIFF
--- a/brew-change
+++ b/brew-change
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # Version information
-readonly VERSION="1.9.0"
+readonly VERSION="1.9.1"
 
 # Set UTF-8 locale to handle emojis and special characters
 # This must be set before any text processing

--- a/lib/brew-change-upgrade.sh
+++ b/lib/brew-change-upgrade.sh
@@ -223,17 +223,6 @@ execute_upgrade() {
             ;;
     esac
 
-    # Final confirmation
-    if [[ ${#cmd_args[@]} -eq 0 ]]; then
-        if ! prompt_upgrade_confirmation "$description"; then
-            return 0
-        fi
-    else
-        if ! prompt_upgrade_confirmation "$description" "${cmd_args[@]}"; then
-            return 0
-        fi
-    fi
-
     echo ""
     if [[ ${#cmd_args[@]} -eq 0 ]]; then
         echo "Running: brew upgrade"


### PR DESCRIPTION
## Summary

Remove the second "Proceed with upgrade? (y/N):" confirmation prompt. The action prompt (all/safe/choose/cancel) already captures user intent — no major CLI asks for confirmation twice.

Flow is now: spinner prompt → execute brew upgrade. User can Ctrl+C at any time.

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5