### PR TITLE
fix(upgrade): use ? prompt char and add line-break after spinner

### DIFF
--- a/brew-change
+++ b/brew-change
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # Version information
-readonly VERSION="1.9.1"
+readonly VERSION="1.9.2"
 
 # Set UTF-8 locale to handle emojis and special characters
 # This must be set before any text processing

--- a/lib/brew-change-interactive.sh
+++ b/lib/brew-change-interactive.sh
@@ -69,7 +69,7 @@ prompt_upgrade_action() {
     echo "Select upgrade mode:" > /dev/tty
     echo "" > /dev/tty
 
-    local prompt_text="[a]ll / [s]afe-only ($safe_count) / [c]hoose / cancel [$default_option]: "
+    local prompt_text="[a]ll / [s]afe-only ($safe_count) / [c]hoose / cancel [$default_option]? "
     local spinner_chars="⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
     local read_timeout=0.1
     local spinner_idx=0
@@ -88,8 +88,9 @@ prompt_upgrade_action() {
         fi
     done
 
-    # Clear the spinner line
+    # Clear the spinner line and move to next line
     printf "\r%*s\r" "$prompt_width" "" > /dev/tty
+    echo "" > /dev/tty
 
     # Empty response -> use default
     if [[ -z "$response" ]]; then


### PR DESCRIPTION
## Changes

- Replace `:` with `?` for standard prompt convention
- Add line-break after spinner so user input appears on clean line

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5