### PR TITLE
fix(upgrade): pass --yes to brew upgrade to skip its confirmation

### DIFF
--- a/brew-change
+++ b/brew-change
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # Version information
-readonly VERSION="1.10.0"
+readonly VERSION="1.10.1"
 
 # Set UTF-8 locale to handle emojis and special characters
 # This must be set before any text processing

--- a/lib/brew-change-upgrade.sh
+++ b/lib/brew-change-upgrade.sh
@@ -225,19 +225,19 @@ execute_upgrade() {
 
     echo ""
     if [[ ${#cmd_args[@]} -eq 0 ]]; then
-        echo "Running: brew upgrade"
+        echo "Running: brew upgrade --yes"
     else
-        echo "Running: brew upgrade ${cmd_args[*]}"
+        echo "Running: brew upgrade --yes ${cmd_args[*]}"
     fi
     echo ""
 
-    # Execute brew upgrade, capturing output
+    # Execute brew upgrade with --yes to skip Homebrew's confirmation prompt
     local upgrade_exit_code=0
 
     if [[ ${#cmd_args[@]} -eq 0 ]]; then
-        brew upgrade || upgrade_exit_code=$?
+        brew upgrade --yes || upgrade_exit_code=$?
     else
-        brew upgrade "${cmd_args[@]}" || upgrade_exit_code=$?
+        brew upgrade --yes "${cmd_args[@]}" || upgrade_exit_code=$?
     fi
 
     echo ""


### PR DESCRIPTION
## Summary

Add `--yes` to `brew upgrade` calls to skip Homebrew's own confirmation prompt. The user already confirmed their action in our interactive prompt — no need for Homebrew to ask again.

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5