### PR TITLE
feat(upgrade): make -u interactive by default, add --dry-run flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ brew-change node
 # Show detailed changelogs for all outdated packages in parallel
 brew-change -a
 
+# Show changelogs with interactive upgrade prompt
+brew-change -u
+
+# Preview upgrades without executing
+brew-change -u --dry-run
+
 # Highlight packages with breaking changes (-b implies -a)
 brew-change -b
 

--- a/brew-change
+++ b/brew-change
@@ -73,8 +73,9 @@ Options:
   -a, --all            Show detailed changelog for all outdated packages (parallel)
   -v, --verbose        Show outdated packages with version numbers (like 'brew outdated -v')
   -b, --id-breaking    Highlight packages with breaking changes (implies -a)
-  -u, --upgrade        Show changelogs then offer selective upgrade (implies -a, -b)
-                        Set BREW_CHANGE_UPGRADE_INTERACTIVE=true to enable execution
+  -u, --upgrade        Show changelogs with interactive upgrade prompt (implies -a, -b)
+                        Use --dry-run to preview without executing
+  -n, --dry-run        Preview upgrade without executing (use with -u)
   -h, --help           Show this help message
       --version        Show version information
 
@@ -89,9 +90,8 @@ Examples:
   brew-change -b                # Same as -a -b (shorthand)
   brew-change -b node python    # Check specific packages for breaking changes
   brew-change --id-breaking     # Same as -a -b (long form)
-  brew-change -u                # Show changelogs with upgrade summary
-  BREW_CHANGE_UPGRADE_INTERACTIVE=true brew-change -u
-                                # Show changelogs + interactive upgrade prompt
+  brew-change -u                # Show changelogs + interactive upgrade prompt
+  brew-change -u --dry-run      # Show changelogs + upgrade summary (no execution)
   brew-change                   # Show simple outdated list (package names only)
   brew-change --version         # Show version information
 
@@ -103,6 +103,7 @@ SHOW_ALL="false"
 SHOW_VERSIONS="false"
 IDENTIFY_BREAKING="false"
 UPGRADE_MODE="false"
+DRY_RUN_MODE="false"
 PACKAGES=()
 
 while [[ $# -gt 0 ]]; do
@@ -117,6 +118,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -u|--upgrade)
             UPGRADE_MODE="true"
+            shift
+            ;;
+        -n|--dry-run)
+            DRY_RUN_MODE="true"
             shift
             ;;
         -v|--verbose)
@@ -311,6 +316,11 @@ else
     if [ "$UPGRADE_MODE" = "true" ]; then
         SHOW_ALL="true"
         IDENTIFY_BREAKING="true"
+    fi
+
+    # Export dry-run mode for subprocesses
+    if [ "$DRY_RUN_MODE" = "true" ]; then
+        export DRY_RUN_MODE
     fi
 
     if [ "$SHOW_ALL" = "true" ]; then

--- a/docs/standalone-roadmap.md
+++ b/docs/standalone-roadmap.md
@@ -508,8 +508,8 @@ class BrewChangeCLI {
 1. **Package Manager Integration**
    ```bash
    # Direct integration with package managers
-   brew-change --upgrade-interactive    # Interactive upgrade selection
-   brew-change --dry-run               # Preview upgrades without executing
+   brew-change -u                       # Interactive upgrade selection (implemented)
+   brew-change -u --dry-run             # Preview upgrades without executing (implemented)
    brew-change --backup                # Create rollback points
    ```
 

--- a/lib/brew-change-config.sh
+++ b/lib/brew-change-config.sh
@@ -81,12 +81,6 @@ if [[ -z "${BREW_CHANGE_DOCS_REPO:-}" ]]; then
     readonly BREW_CHANGE_DOCS_REPO="false"
 fi
 
-# Upgrade interactive mode — safety gate for brew upgrade execution
-# Must be "true" to enable the interactive upgrade prompt with -u flag
-if [[ -z "${BREW_CHANGE_UPGRADE_INTERACTIVE:-}" ]]; then
-    BREW_CHANGE_UPGRADE_INTERACTIVE="false"
-fi
-
 # Calculate optimal parallel jobs based on system resources
 cpu_count=1
 memory_gb=1

--- a/lib/brew-change-upgrade.sh
+++ b/lib/brew-change-upgrade.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Upgrade orchestration functions for brew-change
 # Handles the interactive selective upgrade flow triggered by -u/--upgrade flag
+# Use -n/--dry-run with -u to preview without executing
 
 # Arrays populated by collect_upgrade_status
 BREAKING_PKGS=()
@@ -106,7 +107,6 @@ print_upgrade_suggestion() {
     fi
 
     echo ""
-    echo "Tip: Set BREW_CHANGE_UPGRADE_INTERACTIVE=true to enable the interactive upgrade prompt."
 }
 
 # Run the interactive upgrade flow
@@ -125,7 +125,13 @@ run_upgrade_prompt() {
     # Print summary (always shown in upgrade mode)
     print_upgrade_summary "$outdated_packages"
 
-    # Non-interactive mode: print suggestion and exit
+    # Dry-run mode: print suggestion and exit without executing
+    if [[ "${DRY_RUN_MODE:-false}" == "true" ]]; then
+        print_upgrade_suggestion "$outdated_packages"
+        return 0
+    fi
+
+    # Non-interactive mode (piped input): print suggestion and exit
     if ! is_interactive_mode; then
         echo ""
         echo "Non-interactive mode. Upgrade skipped."
@@ -133,12 +139,6 @@ run_upgrade_prompt() {
             echo "Suggested safe upgrade: brew upgrade ${SAFE_PKGS[*]}"
         fi
         echo "To upgrade all: brew upgrade"
-        return 0
-    fi
-
-    # Check safety gate: env var must be true for interactive prompt
-    if [[ "$BREW_CHANGE_UPGRADE_INTERACTIVE" != "true" ]]; then
-        print_upgrade_suggestion "$outdated_packages"
         return 0
     fi
 


### PR DESCRIPTION
## Summary

The `-u` flag now launches the interactive upgrade prompt directly instead of requiring `BREW_CHANGE_UPGRADE_INTERACTIVE=true` env var.

## Motivation

The previous behavior violated the **principle of least surprise** — every major CLI tool (npm, brew, pip, cargo, yarn, pnpm, mise) executes upgrades by default when an upgrade/update command is invoked. Requiring an env var to unlock execution is an anti-pattern per [clig.dev](https://clig.dev/).

## Changes

- **`-u` is now interactive by default** — shows changelogs + prompt (all/safe/choose/cancel)
- **Add `-n`/ `--dry-run` flag** — preview-only mode (advisory output, no execution)
- **Remove `BREW_CHANGE_UPGRADE_INTERACTIVE` env var gate** entirely
- Update usage text, examples, README, and roadmap

## Behavior Matrix

| Command | Before | After |
|---------|--------|-------|
| `brew-change -u` | Advisory only (suggestions) | Interactive prompt |
| `brew-change -u --dry-run` | N/A | Advisory only (old default) |
| `BREW_CHANGE_UPGRADE_INTERACTIVE=true brew-change -u` | Interactive prompt | Interactive prompt (env var ignored) |

## Breaking Change

Users who relied on `brew-change -u` for advisory-only output should switch to `brew-change -u --dry-run`.

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5