### PR TITLE
fix(upgrade): add quit key and default to safe on unknown input

### DIFF
--- a/lib/brew-change-interactive.sh
+++ b/lib/brew-change-interactive.sh
@@ -68,12 +68,12 @@ prompt_upgrade_action() {
     local prompt_text
     if [[ "$breaking_count" -eq 0 ]]; then
         # All packages safe — no need for separate safe-only option
-        prompt_text="[a]ll (safe) / [c]hoose / cancel [$default_option]? "
+        prompt_text="[a]ll (safe) / [c]hoose / [q]uit [$default_option]? "
     elif [[ "$safe_count" -eq 0 ]]; then
         # No safe packages — hide safe-only option
-        prompt_text="[a]ll / [c]hoose / cancel [$default_option]? "
+        prompt_text="[a]ll / [c]hoose / [q]uit [$default_option]? "
     else
-        prompt_text="[a]ll / [s]afe-only ($safe_count) / [c]hoose / cancel [$default_option]? "
+        prompt_text="[a]ll / [s]afe-only ($safe_count) / [c]hoose / [q]uit [$default_option]? "
     fi
 
     # Helper text
@@ -119,7 +119,8 @@ prompt_upgrade_action() {
         a|all)    echo "all" ;;
         s|safe)   echo "safe" ;;   # Accepted even when not shown (backward compat)
         c|choose) echo "choose" ;;
-        *)        echo "cancel" ;;
+        q|quit)   echo "cancel" ;;
+        *)        echo "$default_option" ;;   # Unknown key -> use default instead of cancelling
     esac
 }
 


### PR DESCRIPTION
## Summary

The interactive upgrade prompt uses single-character input with no Enter needed, so every keystroke triggers an action. This made the `cancel` option undiscoverable — there was no dedicated key for it.

## Changes

- **Rename `cancel` → `[q]uit`** — dedicated key like the other options
- **Unknown key → default option** instead of cancelling — safer since users can't undo an accidental keystroke

```
Before: [a]ll / [s]afe-only (13) / [c]hoose / cancel [s]?
After:  [a]ll / [s]afe-only (13) / [c]hoose / [q]uit [s]?
```

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5