### PR TITLE
fix(upgrade): fix spinner animation by moving stty setup outside loop

### DIFF
--- a/lib/brew-change-interactive.sh
+++ b/lib/brew-change-interactive.sh
@@ -87,6 +87,11 @@ prompt_upgrade_action() {
 
     local response=""
 
+    # Set non-blocking input once before the loop for smooth animation
+    local stty_saved
+    stty_saved="$(stty -g)"
+    stty -icanon min 0 time 1 2>/dev/null
+
     while [[ -z "$response" ]]; do
         # Draw spinner in-place via carriage return
         local frame=" ${spinner_chars:spinner_idx:1}"
@@ -94,21 +99,20 @@ prompt_upgrade_action() {
         spinner_idx=$(( (spinner_idx + 1) % ${#spinner_chars} ))
 
         # Poll for single-character input (no ENTER required)
-        # Uses -icanon for non-blocking poll without disabling echo or signals
-        local stty_saved
-        stty_saved="$(stty -g)"
-        stty -icanon min 0 time 1 2>/dev/null
         IFS= read -r -n 1 char 2>/dev/null || char=""
-        stty "$stty_saved" 2>/dev/null
 
         if [[ -n "$char" ]]; then
             # Clear spinner, redraw prompt, echo the character on clean line
+            stty "$stty_saved" 2>/dev/null
             printf "\r%*s\r" "$prompt_width" "" > /dev/tty
             printf "%s%s" "$prompt_text" "$char" > /dev/tty
             echo "" > /dev/tty
             response="$char"
         fi
     done
+
+    # Restore terminal settings if loop exited without input
+    [[ -z "$response" ]] && stty "$stty_saved" 2>/dev/null
 
     # Empty response -> use default
     if [[ -z "$response" ]]; then


### PR DESCRIPTION
The spinner appeared frozen because `stty -g` / `stty -icanon` was saved and restored on every 100ms poll cycle, adding heavy overhead. Move the setup before the loop and restore only on character read or exit.

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5