### PR TITLE
chore: bump version to 1.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Spinner output**: Clear spinner frame in the foreground before redrawing prompt to fix duplicate line artifact.
+
+### Fixed
 - **Spinner animation**: Rewrite using background subshell for smooth ~8 FPS animation independent of the blocking read.
 
 ### Fixed

--- a/brew-change
+++ b/brew-change
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # Version information
-readonly VERSION="1.11.4"
+readonly VERSION="1.11.5"
 
 # Set UTF-8 locale to handle emojis and special characters
 # This must be set before any text processing


### PR DESCRIPTION
Patch version bump for the spinner duplicate line fix.